### PR TITLE
Allow alternative local paths if fully defined

### DIFF
--- a/src/ios/MNowPlaying.m
+++ b/src/ios/MNowPlaying.m
@@ -126,7 +126,7 @@
         // check whether artwork path is present
         if (![url isEqual: @""]) {
             // artwork is url download from the interwebs
-            if ([url hasPrefix: @"http://"] || [url hasPrefix: @"https://"]) {
+            if ([url hasPrefix: @"http://"] || [url hasPrefix: @"https://"] || [url hasPrefix: @"file://"] || [url hasPrefix: @"cdvfile://"]) {
                 NSURL *imageURL = [NSURL URLWithString:url];
                 NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
                 image = [UIImage imageWithData:imageData];


### PR DESCRIPTION
Treat file:// and cdvfile:// prefixes the same way interwebs artwork is treated. This allows developers to use artwork that isn't limited to the documents folder.